### PR TITLE
Get rid of all sleep()s in tests

### DIFF
--- a/signalbot/signalbot.py
+++ b/signalbot/signalbot.py
@@ -171,10 +171,12 @@ class Signalbot(object):
             self._thread.start()
 
             if self._config['startup_notification']:
-                master_chat_id = Chat.get_id_from_sender_and_group_id(
-                    self._config['master'])
-                master_chat = self._get_chat_by_id(master_chat_id)
-                self.send_success('Always at your service!', [], master_chat)
+                for master in self._config['master']:
+                    master_chat_id = Chats.get_id_from_sender_and_group_id(
+                        master)
+                    master_chat = self._chats.get(master_chat_id, store=True)
+                    self.send_success('Always at your service!', [],
+                                      master_chat)
 
         except Exception as e:
             # Try not to leave empty temporary directories behind when e.g. a

--- a/signalbot/signalbot.py
+++ b/signalbot/signalbot.py
@@ -25,7 +25,7 @@ class Chats(dict):
         return super().get(key, default)
 
     @staticmethod
-    def get_id_from_sender_and_group_id(sender, group_id):
+    def get_id_from_sender_and_group_id(sender, group_id=[]):
         if group_id != []:
             # Ensure we have a hashable id
             return tuple(group_id)
@@ -98,6 +98,7 @@ class Signalbot(object):
             'master': None,
             'plugins': [],
             'testing_plugins': [],
+            'startup_notification': False,
         }
 
         self._configfile = Path.joinpath(self._data_dir, 'config.yaml')
@@ -168,6 +169,13 @@ class Signalbot(object):
             self._loop = GLib.MainLoop()
             self._thread = Thread(daemon=True, target=self._loop.run)
             self._thread.start()
+
+            if self._config['startup_notification']:
+                master_chat_id = Chat.get_id_from_sender_and_group_id(
+                    self._config['master'])
+                master_chat = self._get_chat_by_id(master_chat_id)
+                self.send_success('Always at your service!', [], master_chat)
+
         except Exception as e:
             # Try not to leave empty temporary directories behind when e.g. a
             # plugin fails to load

--- a/signalbot/tests/__init__.py
+++ b/signalbot/tests/__init__.py
@@ -85,7 +85,7 @@ class HelloWorldTest(unittest.TestCase):
              [], ['+123']],
             ['backup_B: Attempting to acquire exclusive lock...',
              [], ['+123']],
-            ['Exclusive lock could not be acquired. ❌', [], ['+123']],
+            ['Isolation lock could not be acquired. ❌', [], ['+123']],
             ['backup_C: Attempting to acquire exclusive lock...',
              [], ['+123']],
             ['We want to do our own handling if we cannot get the exclusive '

--- a/signalbot/tests/__init__.py
+++ b/signalbot/tests/__init__.py
@@ -34,10 +34,9 @@ class HelloWorldTest(unittest.TestCase):
         self.tempdir.cleanup()
 
     def _assert_expected_messages(self, expect_messages):
-        self.assertCountEqual([['Always at your service! ✔', [], ['+123']]] +
-                              expect_messages,
-                              [have[1:]
-                               for have in self.mocker.fromsignalbot])
+        self.assertEqual([['Always at your service! ✔', [], ['+123']]] +
+                         expect_messages,
+                         [have[1:] for have in self.mocker.fromsignalbot])
 
     def test_master(self):
         self.mocker.messageSignalbot('+000', None, '//enable pingpong', [])
@@ -86,12 +85,12 @@ class HelloWorldTest(unittest.TestCase):
              [], ['+123']],
             ['backup_B: Attempting to acquire exclusive lock...',
              [], ['+123']],
+            ['Exclusive lock could not be acquired. ❌', [], ['+123']],
             ['backup_C: Attempting to acquire exclusive lock...',
              [], ['+123']],
-            ['backup_A: Locked - sleeping 1 sec ...', [], ['+123']],
-            ['backup_A: ... done sleeping / locking', [], ['+123']],
-            ['Exclusive lock could not be acquired. ❌', [], ['+123']],
             ['We want to do our own handling if we cannot get the exclusive '
              'lock. ❌', [], ['+123']],
+            ['backup_A: Locked - sleeping 1 sec ...', [], ['+123']],
+            ['backup_A: ... done sleeping / locking', [], ['+123']],
         ]
         self._assert_expected_messages(expect_messages)

--- a/signalbot/tests/plugin_pingponglocktest.py
+++ b/signalbot/tests/plugin_pingponglocktest.py
@@ -7,8 +7,10 @@ class PingPongLockTestChat(PluginChat):
     def triagemessage(self, message):
 
         if message.text in ['backup_A', 'backup_B', 'backup_C']:
-            if message.text != 'backup_A':
-                sleep(1)
+            if message.text == 'backup_B':
+                sleep(.3)
+            elif message.text == 'backup_C':
+                sleep(.6)
             self.reply("{}: Attempting to acquire exclusive lock...".format(
                 message.text))
             if message.text in ['backup_A', 'backup_B']:

--- a/signalbot/tests/plugin_pingponglocktest.py
+++ b/signalbot/tests/plugin_pingponglocktest.py
@@ -36,6 +36,7 @@ class PingPongLockTestChat(PluginChat):
             return
 
         elif message.text == 'backup':
+            sleep(.3)
             self.reply("Acquiring lock...")
             with self.isolated_thread:
                 self.reply("Locked - sleeping 1 sec ...")

--- a/signalbot/tests/plugin_pingponglocktest.py
+++ b/signalbot/tests/plugin_pingponglocktest.py
@@ -7,10 +7,12 @@ class PingPongLockTestChat(PluginChat):
     def triagemessage(self, message):
 
         if message.text in ['backup_A', 'backup_B', 'backup_C']:
-            if message.text == 'backup_B':
+            if message.text == 'backup_A':
                 sleep(.3)
-            elif message.text == 'backup_C':
+            elif message.text == 'backup_B':
                 sleep(.6)
+            elif message.text == 'backup_C':
+                sleep(.9)
             self.reply("{}: Attempting to acquire exclusive lock...".format(
                 message.text))
             if message.text in ['backup_A', 'backup_B']:

--- a/signalbot/tests/plugin_pingponglocktest.py
+++ b/signalbot/tests/plugin_pingponglocktest.py
@@ -1,4 +1,4 @@
-from signalbot.plugins import PluginChat, ExclusivityException
+from signalbot.plugins import PluginChat, IsolationException
 from time import sleep
 
 
@@ -30,7 +30,7 @@ class PingPongLockTestChat(PluginChat):
                         sleep(1)
                         self.reply("{}: ... done sleeping / locking".format(
                             message.text))
-                except ExclusivityException:
+                except IsolationException:
                     self.error('We want to do our own handling if we cannot '
                                'get the exclusive lock.')
             return

--- a/signalclidbusmock/mocker.py
+++ b/signalclidbusmock/mocker.py
@@ -17,12 +17,20 @@ class Mocker(object):
         self._thread = Thread(target=self._loop.run, daemon=True)
         self._thread.start()
         self.tosignalbot = []
+        self._wait_until = 0
 
     def messageSignalbot(self, sender, group_id, text, attachmentfiles):
         self._mock.MessageReceived(int(time.time()),
                                    sender, group_id, text, attachmentfiles)
         self.tosignalbot.append([int(time.time()),
                                  sender, group_id, text, attachmentfiles])
+
+    def _wait_until_n_messages(self, n=1, timeout=1):
+        return self._mock.wait_until_n_messages(n=n, timeout=timeout)
+
+    def wait_for_n_messages(self, n=1, timeout=1):
+        self._wait_until += n
+        self._wait_until_n_messages(n=self._wait_until, timeout=timeout)
 
     @property
     def fromsignalbot(self):


### PR DESCRIPTION
The tests sometimes failed and also took longer than needed due to the sleep calls. The function of most sleep()s is  to wait until a number of messages was received from the Signalbot. Those cases can now be handled by a new method Mocker.wait_for_n_messages.

There is also one sleep call whose function is to wait until the cli.py has exectuted and Signalbot is ready to respond to incoming messages. To be able to remove this sleep call, the Signalbot can now send a startup notification to the master user once it has finished starting up.